### PR TITLE
only create `profile.d` layer if the directory exists

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -27,10 +27,12 @@ echo "cache = true" > ${layers_dir}/shim.toml
 "${target_dir}/bin/compile" "$(pwd)" "${cache_dir}" "${platform_dir}/env"
 
 # copy profile.d scripts into a layer so they will be sourced
-profile_dir="${layers_dir}/profile"
-mkdir -p "${profile_dir}/profile.d"
-cp .profile.d/* "${profile_dir}/profile.d/"
-echo "launch = true" > "${profile_dir}.toml"
+if [ -d .profile.d ]; then
+	profile_dir="${layers_dir}/profile"
+	mkdir -p "${profile_dir}/profile.d"
+	cp .profile.d/* "${profile_dir}/profile.d/"
+	echo "launch = true" > "${profile_dir}.toml"
+fi
 
 if [[ -f "${target_dir}/export" ]]; then
   echo "build = true" >> "${profile_dir}.toml"


### PR DESCRIPTION
the cnb-shim will always try to copy the `.profile.d` directory over and create a layer for it, but this will lead to an error if the buildpack doesn't create it.

```
cp: cannot stat '.profile.d/*': No such file or directory
```

This change now conditionally creates the layer if the buildpack is created a `.profile.d` directory.