### PR TITLE
Wrap detect failures in a more CNB friendly manner

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -2,12 +2,15 @@
 
 # fail hard
 set -o pipefail
-# fail harder
-set -eu
 
 bp_dir="$(cd $(dirname $0)/..; pwd)" # absolute path
 target_dir="${bp_dir}/target"
 
 "${target_dir}/bin/detect" "$(pwd)" > /dev/null 2>&1
 
-exit $?
+EXITCODE=$?
+
+case $EXITCODE in
+    1) exit 100;;
+    *) exit $EXITCODE;;
+esac


### PR DESCRIPTION
Cloud Native Buildpacks should default to exiting with a code of `100` to be `failed`.

[Spec](https://github.com/buildpacks/spec/blob/master/buildpack.md#detection)