### PR TITLE
Is it bug?

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -41,4 +41,4 @@ if [[ -f "${target_dir}/export" ]]; then
 fi
 
 # run bin/release, read Procfile, and generate launch.toml
-"${bp_dir}/bin/release" "${target_dir}" "${layers_dir}" "${platform_dir}"
+"${bp_dir}/bin/release" "${target_dir}" "${layers_dir}" "${platform_dir}" "$(pwd)"

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -10,8 +10,8 @@ import (
 )
 
 func main() {
-	if len(os.Args) != 4 {
-		fmt.Println("Usage:", os.Args[0], "TARGET_BUILDPACK_DIR", "LAYERS_DIR", "PLATFORM_DIR")
+	if len(os.Args) != 5 {
+		fmt.Println("Usage:", os.Args[0], "TARGET_BUILDPACK_DIR", "LAYERS_DIR", "PLATFORM_DIR", "APP_DIR")
 		return
 	}
 
@@ -24,7 +24,7 @@ func main() {
 	targetDir := os.Args[1]
 	layersDir := os.Args[2]
 
-	appDir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	appDir, err := filepath.Abs(os.Args[4])
 	if err != nil {
 		log.Info(err.Error())
 		os.Exit(2)


### PR DESCRIPTION
When i use [heroku-buildpack-gradle](https://github.com/heroku/heroku-buildpack-gradle)
shim doesn't seem to be able to automatically inject the startup cmd for spring boot app.
I solved it like below but I wonder if this is intended.