### PR TITLE
Add .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: cimg/go:1.14
+    steps:
+      - checkout
+
+      - restore_cache: # restores saved cache if no changes are detected since last run
+          keys:
+            - go-mod-{{ checksum "go.sum" }}
+
+      - run:
+          name: Test
+          command: |
+            make test
+
+      - run:
+          name: Build
+          command: |
+            make build
+
+      - save_cache:
+          key: go-mod-{{ checksum "go.sum" }}
+          paths:
+            - "/go/pkg/mod"
+
+workflows:
+  build-workflow:
+    jobs:
+      - build


### PR DESCRIPTION
Add a simple circle ci config to test and build the project. 

Note: This uses the `Makefile` commands, which currently only test `go` bits of this repo. There are no ruby tests yet, but we can add them and update the `Makefile`.