### PR TITLE
Add app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,29 @@
+{
+    "name": "cnb-shim",
+    "keywords": [],
+    "stack": "heroku-18",
+    "addons": [],
+    "env": {
+      "LANG": {
+        "value": "en_US.UTF-8",
+        "required": true
+      },
+      "RACK_ENV": {
+        "value": "production",
+        "required": true
+      }
+    },
+    "formation": {
+      "web": {
+        "quantity": 1
+      }
+    },
+    "buildpacks": [
+      {
+        "url": "heroku/go"
+      },
+      {
+        "url": "heroku/ruby"
+      }
+    ]
+  }


### PR DESCRIPTION
Add default app.json with proper buildpacks. The pipeline has review apps on and this type of app is actually pretty nice to use with Review Apps since it produces an output that needs to be inspected/used by the builder. It wasn't working as-is, because the go buildpack was not being executed.


This is currently blocked by https://github.com/heroku/cnb-shim/pull/16, now that I required CircleCI checks on PRs.