### PR TITLE
Setup rollbar for the ruby server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ ruby '>= 2.7.1', '< 2.8'
 
 gem 'sinatra'
 gem 'puma'
+gem 'rollbar'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
     rack (2.2.3)
     rack-protection (2.0.8.1)
       rack
+    rollbar (3.1.1)
     ruby2_keywords (0.0.2)
     sinatra (2.0.8.1)
       mustermann (~> 1.0)
@@ -19,10 +20,15 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-19
 
 DEPENDENCIES
   puma
+  rollbar
   sinatra
 
+RUBY VERSION
+   ruby 2.7.2p137
+
 BUNDLED WITH
-   2.1.2
+   2.2.1

--- a/main.rb
+++ b/main.rb
@@ -7,13 +7,8 @@ require 'securerandom'
 
 Bundler.require
 
-require 'rollbar/request_data_extractor'
-class RequestDataExtractor
-  extend Rollbar::RequestDataExtractor
-  def self.from_rack(env)
-    extract_request_data_from_rack(env).merge(route: env["PATH_INFO"])
-  end
-end
+require 'rollbar/middleware/sinatra'
+use Rollbar::Middleware::Sinatra
 
 configure do
   if ENV.key?('ROLLBAR_ACCESS_TOKEN')
@@ -27,11 +22,6 @@ end
 
 configure { set :server, :puma }
 configure { set :port, ENV['PORT'] || 5000 }
-
-error do
-  req_data = RequestDataExtractor.from_rack(env)
-  Rollbar.report_exception(env['sinatra.error'], req_data)
-end
 
 get '/v1/:namespace/:name' do
   id = "#{params['namespace']}/#{params['name']}"


### PR DESCRIPTION
This should give us some insight into why the shim fails.

Prior to deploy:

- [x] Set ROLLBAR_ACCESS_TOKEN in staging
- [x] Set ROLLBAR_ACCESS_TOKEN in production
- [x] Set ROLLBAR_ENVIRONMENT=staging in staging
- [x] Set ROLLBAR_ENVIRONMENT=production in prod