### PR TITLE
Update README.md with correct sbin/path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SHELL=/bin/bash -o pipefail
 
 GO111MODULE := on
 
-VERSION := "v0.2"
+VERSION := "v0.3"
 
 build:
 	@GOOS=linux go build -o "bin/release" ./cmd/release/...
@@ -25,7 +25,7 @@ clean:
 	-rm -f bin/release
 
 package: clean build
-	@tar cvzf cnb-shim-$(VERSION).tgz bin/ README.md LICENSE
+	@tar cvzf cnb-shim-$(VERSION).tgz bin/ sbin/ README.md LICENSE
 
 release:
 	@git tag $(VERSION)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ heroku buildpacks:search
 To use the shim manually, install the target buildpack:
 
 ```sh-session
-$ bin/install "path/to/buildpack.toml" "https://example.com/buildpack.tgz"
+$ sbin/install "path/to/buildpack.toml" "https://example.com/buildpack.tgz"
 ```
 
 Then run this buildpack.
@@ -53,7 +53,7 @@ name = "Elixir"
 id = "heroku-18"
 TOML
 
-$ bin/install buildpack.toml https://buildpack-registry.s3.amazonaws.com/buildpacks/hashnuke/elixir.tgz
+$ sbin/install buildpack.toml https://buildpack-registry.s3.amazonaws.com/buildpacks/hashnuke/elixir.tgz
 
 $ cd ~/my-elixir-app/
 


### PR DESCRIPTION
The README was referencing a script that was moved. Update to reflect reality.
The release artifact was also not including the `sbin/install` script, so I updated the packaging to include it.
Bump version for upcoming cut of release