### PR TITLE
Close network request with 400 when downloading an invalid buildpack.

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -60,6 +60,7 @@ func NameHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	shimDir, _ := os.Getwd()
+	log.Infof("at=shimDir dir=%s", shimDir)
 
 	shimmedBuildpack := fmt.Sprintf("%s.tgz", uuid.New())
 	dir, _ := os.Getwd()

--- a/server/main.go
+++ b/server/main.go
@@ -143,15 +143,10 @@ func NameHandler(w http.ResponseWriter, r *http.Request) {
 
 	fstat, err := file.Stat()
 	handlePanic(err)
-	if err != nil {
-		log.Errorf("at=bad-request file=%s", shimmedBuildpack)
-		w.WriteHeader(http.StatusBadRequest)
-	} else {
-		log.Infof("at=send file=%s size=%d", shimmedBuildpack, fstat.Size())
-		w.Header().Add("Content-Type", "application/x-gzip")
-		http.ServeFile(w, r, shimmedBuildpack)
-		log.Infof("at=success file=%s", shimmedBuildpack)
-	}
+	log.Infof("at=send file=%s size=%d", shimmedBuildpack, fstat.Size())
+	w.Header().Add("Content-Type", "application/x-gzip")
+	http.ServeFile(w, r, shimmedBuildpack)
+	log.Infof("at=success file=%s", shimmedBuildpack)
 }
 
 func HealthHandler(w http.ResponseWriter, r *http.Request) {

--- a/server/main.go
+++ b/server/main.go
@@ -116,10 +116,15 @@ func NameHandler(w http.ResponseWriter, r *http.Request) {
 
 	fstat, err := file.Stat()
 	handlePanic(err)
-	log.Infof("at=send file=%s size=%d", shimmedBuildpack, fstat.Size())
-	w.Header().Add("Content-Type", "application/x-gzip")
-	http.ServeFile(w, r, shimmedBuildpack)
-	log.Infof("at=success file=%s", shimmedBuildpack)
+	if err != nil {
+		log.Errorf("at=bad-request file=%s", shimmedBuildpack)
+		w.WriteHeader(http.StatusBadRequest)
+	} else {
+		log.Infof("at=send file=%s size=%d", shimmedBuildpack, fstat.Size())
+		w.Header().Add("Content-Type", "application/x-gzip")
+		http.ServeFile(w, r, shimmedBuildpack)
+		log.Infof("at=success file=%s", shimmedBuildpack)
+	}
 }
 
 func HealthHandler(w http.ResponseWriter, r *http.Request) {

--- a/server/main.go
+++ b/server/main.go
@@ -138,7 +138,9 @@ func HealthHandler(w http.ResponseWriter, r *http.Request) {
 
 func handlePanic(e error) {
 	if e != nil {
-		log.Panic(e)
+		rollbar.WrapAndWait(func() {
+			log.Panic(e)
+		})
 	}
 }
 

--- a/server/main.go
+++ b/server/main.go
@@ -59,12 +59,15 @@ func NameHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	shimDir, _ := os.Getwd()
+	shimDir, err := os.Getwd()
+	handlePanic(err)
 	log.Infof("at=shimDir dir=%s", shimDir)
 
 	shimmedBuildpack := fmt.Sprintf("%s.tgz", uuid.New())
-	dir, _ := os.Getwd()
-	dir, _ = ioutil.TempDir(dir, uuid.New().String())
+	dir, err := os.Getwd()
+	handlePanic(err)
+	dir, err = ioutil.TempDir(dir, uuid.New().String())
+	handlePanic(err)
 	defer os.RemoveAll(dir)
 	handlePanic(os.Chdir(dir))
 


### PR DESCRIPTION
Any panic will leave the server in a bad state since the request is not closed. This will cause every other request after to not be processed properly.