### PR TITLE
Add heroku-22 to default stacks

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -76,7 +76,7 @@ func NameHandler(w http.ResponseWriter, r *http.Request) {
 
 	if stacks = params.Get("stacks"); stacks == "" {
 		if stack := params.Get("stack"); stack == "" {
-			stacks = "heroku-18,heroku-20"
+			stacks = "heroku-18,heroku-20,heroku-22"
 		} else {
 			stacks = stack
 		}


### PR DESCRIPTION
In preparation of the upcoming `heroku/heroku:22` stack image and `heroku/buildpacks:22` builder, it probably makes sense to expand the default stacks to `heroku-22`. This will make shimmed buildpacks usable on `heroku-22` by default (they currently are not usable without a "stacks" query parameter).