### PR TITLE
Ensure generated archives are deterministic

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -136,7 +136,10 @@ func NameHandler(w http.ResponseWriter, r *http.Request) {
 	handlePanic(err)
 	handlePanic(os.Remove(bp))
 
-	cmd := fmt.Sprintf("tar cz --file=%s --directory=%s .", shimmedBuildpack, dir)
+	// The sort, mtime and owner options ensure the archive is deterministic across time and dynos
+	// (since the user ID varies by dyno). See: https://reproducible-builds.org/docs/archives/
+	// This helps reduce layer churn in builder images containing shimmed buildpacks.
+	cmd := fmt.Sprintf("tar -cz --file=%s --directory=%s --sort=name --mtime='1980-01-01 00:00:01Z' --owner=0 --group=0 --numeric-owner .", shimmedBuildpack, dir)
 
 	_, err = exec.Command("bash", "-c", cmd).Output()
 	handlePanic(err)


### PR DESCRIPTION
Previously each request to `cnb-shim` for the same buildpack would result in a tarfile with varying contents even if the underlying buildpack hadn't changed).

This was due to:
- the dynamically generated parts of the shimmed buildpack having "now" timestamps
- the archive containing the user ID of the current dyno, which varies between dynos (and requests to cnb-shim can hit any of its `web` dynos, plus dynos are cycled every 24 hours).

Now, repeat requests result in an identical archive, so long as the buildpack or shim scripts haven't changed.

This helps reduce layer churn in builder images containing shimmed buildpacks, such as our new `heroku/builder-classic:22` builder, or the older `heroku/buildpacks:{18,22}` builders.

GUS-W-11277378.