### PR TITLE
Remove `heroku-18` from app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,6 @@
 {
     "name": "cnb-shim",
     "keywords": [],
-    "stack": "heroku-18",
     "addons": [],
     "env": {
       "LANG": {


### PR DESCRIPTION
Since the staging/production apps are using Heroku-22, (which is the default stack), so we should be running review apps on Heroku-22 too.