### PR TITLE
Update Buildpack API from 0.4 to 0.8

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -25,7 +25,10 @@ chmod -R +w "$target_dir"
 # create a shim cache layer
 cache_dir="${layers_dir}/shim"
 mkdir -p "${cache_dir}"
-echo "cache = true" >"${layers_dir}/shim.toml"
+cat > "${cache_dir}.toml" <<-EOL
+[types]
+cache = true
+EOL
 
 "${target_dir}/bin/compile" "$(pwd)" "${cache_dir}" "${platform_dir}/env"
 
@@ -34,7 +37,10 @@ if [[ -d .profile.d ]]; then
 	profile_dir="${layers_dir}/profile"
 	mkdir -p "${profile_dir}/profile.d"
 	cp .profile.d/* "${profile_dir}/profile.d/"
-	echo "launch = true" >"${profile_dir}.toml"
+	cat > "${profile_dir}.toml" <<-EOL
+	[types]
+	launch = true
+	EOL
 fi
 
 if [[ -f "${target_dir}/export" ]]; then

--- a/server/main.go
+++ b/server/main.go
@@ -71,7 +71,7 @@ func NameHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if api = params.Get("api"); api == "" {
-		api = "0.4"
+		api = "0.8"
 	}
 
 	if stacks = params.Get("stacks"); stacks == "" {


### PR DESCRIPTION
Buildpack API 0.4 has been deprecated in lifecycle 0.16.0, and so the CNBs generated by cnb-shim currently result in deprecation warnings:

eg:

```
===> DETECTING
Warning: Buildpack 'heroku/ruby@0.0.0' requests deprecated API '0.4'
Warning: Buildpack 'heroku/clojure@0.0.0' requests deprecated API '0.4'
Warning: Buildpack 'heroku/python@0.0.0' requests deprecated API '0.4'
Warning: Buildpack 'heroku/java@0.0.0' requests deprecated API '0.4'
Warning: Buildpack 'heroku/gradle@0.0.0' requests deprecated API '0.4'
Warning: Buildpack 'heroku/scala@0.0.0' requests deprecated API '0.4'
Warning: Buildpack 'heroku/php@0.0.0' requests deprecated API '0.4'
Warning: Buildpack 'heroku/go@0.0.0' requests deprecated API '0.4'
Warning: Buildpack 'heroku/nodejs@0.0.0' requests deprecated API '0.4'
```

From:
https://github.com/heroku/builder/actions/runs/4670233967/jobs/8269751652#step:9:9

As such, the default Buildpack API version has been increased from 0.4 to 0.8. This required adding the `[types]` table to the layer TOML files, per: https://github.com/buildpacks/rfcs/blob/main/text/0074-layer-table.md

The Buildpack API hasn't been updated even further (to 0.9), since that will require further changes due to the removal of implicit bash support and `direct = false`, and 0.8 isn't deprecated so is fine to use for now.

Changes:
https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.5
https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.6
https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.7
https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.8

GUS-W-12541119.