### PR TITLE
Fix the default `name` if none is specified via a URL parameter

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -67,7 +67,7 @@ func NameHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if name = params.Get("name"); name == "" {
-		name = "0.1"
+		name = id
 	}
 
 	if api = params.Get("api"); api == "" {


### PR DESCRIPTION
Previously if no `&name=...` parameter was specified in the URL, then the default buildpack `name` (the string used for display purposes only, not to be confused by the buildpack `id`) defaulted to `"0.1"`, which appears to be a copy-paste mistake when the URL handling was added.

Now, if no `name` is specified, it defaults to the same value as the buildpack `id`, which will be less pretty in the build logs than a user-provided name (such as "Python"), but at least clearer than "0.1". There are no restrictions on what characters can go in the `name` (unlike `id`), so using the `id` as the `name` will always be valid:
https://github.com/buildpacks/spec/blob/main/buildpack.md#buildpacktoml-toml

No test has been added, since this project currently has zero integration tests of the server component :-(
I will test manually using the Review App instead.

GUS-W-12541186.