### PR TITLE
Remove Heroku-18 from the default stacks list

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ version = "0.1"
 name = "Elixir"
 
 [[stacks]]
-id = "heroku-18"
+id = "heroku-22"
 TOML
 
 $ sbin/install buildpack.toml https://buildpack-registry.s3.amazonaws.com/buildpacks/hashnuke/elixir.tgz

--- a/server/main.go
+++ b/server/main.go
@@ -76,7 +76,7 @@ func NameHandler(w http.ResponseWriter, r *http.Request) {
 
 	if stacks = params.Get("stacks"); stacks == "" {
 		if stack := params.Get("stack"); stack == "" {
-			stacks = "heroku-18,heroku-20,heroku-22"
+			stacks = "heroku-20,heroku-22"
 		} else {
 			stacks = stack
 		}


### PR DESCRIPTION
Since the Heroku-18 stack has now reached end-of-life:
https://devcenter.heroku.com/changelog-items/2583

Anyone who needs shimmed CNBs to list `heroku-18` in the generated `buildpack.toml`'s `stacks` list will now need to pass in a list of stacks explicitly in the URL, eg:
`&stacks=heroku-18,heroku-20,heroku-22`

Longer term we should probably change this default `stacks` list to just be the wildcard stack (`*`) instead, however that requires Buildpack API 0.5+, and cnb-shim is still on Buildpack API 0.4 (see #73).

GUS-W-13150845.