### PR TITLE
Add a deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@
 
 [![CI](https://github.com/heroku/cnb-shim/actions/workflows/ci.yml/badge.svg)](https://github.com/heroku/cnb-shim/actions/workflows/ci.yml)
 
-This is a Cloud Native Buildpack that acts as a shim for [Heroku Buildpacks](https://devcenter.heroku.com/articles/buildpacks).
+> [!WARNING]
+> This project is not actively maintained and does not support modern Buildpack API and lifecycle versions.
+>
+> Please switch to native CNB implementations rather than using this shim.
+>
+> See [Heroku's natively supported CNB languages](https://github.com/heroku/buildpacks#supported-languages) or [search for community buildpacks](https://registry.buildpacks.io/).
+
+This is a Cloud Native Buildpack that acts as a shim for classic [Heroku Buildpacks](https://devcenter.heroku.com/articles/buildpacks).
 
 ## Usage
 

--- a/bin/build
+++ b/bin/build
@@ -1,9 +1,19 @@
 #!/usr/bin/env bash
 
-# fail hard
-set -o pipefail
-# fail harder
-set -eu
+set -euo pipefail
+
+ANSI_RED="\033[1;31m"
+ANSI_RESET="\033[0m"
+
+function display_error() {
+	echo >&2
+	# We have to ANSI wrap each line separately to prevent breakage if line prefixes are added
+	# later (such as when the builder is untrusted, or when Git adds the "remote:" prefix).
+	while IFS= read -r line; do
+		echo -e "${ANSI_RED}${line}${ANSI_RESET}" >&2
+	done <<< "${1}"
+	echo >&2
+}
 
 bp_dir=$(
 	cd "$(dirname "$0")/.."
@@ -16,6 +26,87 @@ platform_dir="${2:?}"
 
 # translate new stack ID to old stack ID
 export STACK="$CNB_STACK_ID"
+
+
+if [[ "${STACK}" == "heroku-"* ]]; then
+	if [[ "${ALLOW_EOL_SHIMMED_BUILDER:-}" == "1" ]]; then
+		MSG_PREFIX="WARNING"
+		MSG_FOOTER="Allowing the build to continue since ALLOW_EOL_SHIMMED_BUILDER is set."
+	else
+		MSG_PREFIX="ERROR"
+		MSG_FOOTER="To ignore this error, set the env var ALLOW_EOL_SHIMMED_BUILDER to 1."
+	fi
+
+	display_error "$(cat <<-EOF
+		#######################################################################
+
+		${MSG_PREFIX}: This buildpack is a legacy buildpack that has been shimmed
+		for compatibility with Cloud Native Buildpacks (CNBs) using the
+		cnb-shim service:
+		https://github.com/heroku/cnb-shim
+
+		The cnb-shim service is not actively maintained and does not support
+		modern Buildpack API and lifecycle versions.
+
+		In addition, the legacy builder images that use shimmed buildpacks
+		(such as 'heroku/buildpacks:20' or 'heroku/builder-classic:22') are
+		no longer supported and will soon stop receiving security updates.
+
+		Please switch to one of our newer 'heroku/builder:*' builder images,
+		such as 'heroku/builder:22':
+		https://github.com/heroku/cnb-builder-images#available-images
+
+		If you are using the Pack CLI, you will need to adjust your '--builder'
+		CLI argument, or else change the default builder configuration using:
+		'pack config default-builder <new_builder_name>'
+
+		If you are using a third-party platform to deploy your app, check their
+		documentation for how to adjust the builder image used for your build.
+
+		If you manually specify a cnb-shim buildpack URL (that refers to
+		'cnb-shim.herokuapp.com') you will also need to update that to
+		the ID of a non-shimmed buildpack.
+
+		See here for Heroku's supported CNB languages:
+		https://github.com/heroku/buildpacks#supported-languages
+
+		Or search for community buildpacks here:
+		https://registry.buildpacks.io/
+
+		${MSG_FOOTER}
+
+		#######################################################################
+		EOF
+	)"
+
+	if [[ "${ALLOW_EOL_SHIMMED_BUILDER:-}" != "1" ]]; then
+		exit 1
+	fi
+else
+	display_error "$(cat <<-'EOF'
+		#######################################################################
+
+		WARNING: This buildpack is a legacy buildpack that has been shimmed
+		for compatibility with Cloud Native Buildpacks (CNBs) using the
+		cnb-shim service:
+		https://github.com/heroku/cnb-shim
+
+		The cnb-shim service is not actively maintained and does not support
+		modern Buildpack API and lifecycle versions.
+
+		Please switch to a buildpack that supports CNBs natively and so does
+		not need shimming.
+
+		See here for Heroku's supported CNB languages:
+		https://github.com/heroku/buildpacks#supported-languages
+
+		Or search for community buildpacks here:
+		https://registry.buildpacks.io/
+
+		#######################################################################
+		EOF
+	)"
+fi
 
 # copy the buildpack source into the target dir
 target_dir="$(mktemp -d)/target"


### PR DESCRIPTION
Heroku's legacy shimmed builder images (`heroku/buildpacks:20` and `heroku/builder-classic:22`) are EOL and will soon stop receiving security updates.

We added deprecation warnings to the builder images back in October:
https://github.com/heroku/cnb-builder-images/pull/429

And these warnings were just upgraded to errors:
https://github.com/heroku/cnb-builder-images/pull/478

However, the way these warnings/errors are shown is via the builders default buildpack detection group configuration, which means that if a project provides a custom buildpack list (either via `project.toml`, `--buildpack` args to Pack CLI, or via a third party build tool that overrides the buildpack list), these warnings aren't shown.

For example, as seen in:
https://github.com/apppackio/apppack-codebuild-image/issues/5#issuecomment-2004132334
https://github.com/heroku/buildpacks-nodejs/issues/800#issuecomment-1998654135

As such, I'm adding them directly to cnb-shim, to raise awareness of the Heroku builder image sunset, as well as the deprecated nature of cnb-shim.

The implementation is based on that here:
https://github.com/heroku/cnb-builder-images/blob/88cb8159fff129ab498c2e9a5df9bbaff8ea204a/buildpacks-20/end-of-life-buildpack/bin/build

I've re-used the same `ALLOW_EOL_SHIMMED_BUILDER` env var name, since otherwise it will cause another round of breaking changes for people who've already seen the error message from the builder itself, and have already set that env var.

Since cnb-shim may be being used by non-Heroku builder images too (for which the sunset nature of the builder doesn't apply; only the cnb-shim deprecation), we check the stack ID and vary the message/behaviour accordingly.

GUS-W-15325154.