### PR TITLE
Update EOL message about builder image updates

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -54,10 +54,9 @@ if [[ "${STACK}" == "heroku-"* ]]; then
 
 		In addition, the legacy builder images that use shimmed buildpacks
 		(such as 'heroku/buildpacks:20' or 'heroku/builder-classic:22') are
-		no longer supported and will soon stop receiving security updates.
+		no longer supported and do not receive any security updates or fixes.
 
-		Please switch to one of our newer 'heroku/builder:*' builder images,
-		such as 'heroku/builder:22':
+		Please switch to one of our newer 'heroku/builder:*' builder images:
 		https://github.com/heroku/cnb-builder-images#available-images
 
 		If you are using the Pack CLI, you will need to adjust your '--builder'


### PR DESCRIPTION
Updates the EOL message to reflect that we're now stopping updating these images. I've also removed the explicit builder image name example from the message, since it will get out of date once future builders are released.

This is the cnb-shim equivalent of https://github.com/heroku/cnb-builder-images/pull/513.

Towards heroku/cnb-builder-images#512.