### PR TITLE
Update messaging for upcoming sunset

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,72 +3,10 @@
 [![CI](https://github.com/heroku/cnb-shim/actions/workflows/ci.yml/badge.svg)](https://github.com/heroku/cnb-shim/actions/workflows/ci.yml)
 
 > [!WARNING]
-> This project is not actively maintained and does not support modern Buildpack API and lifecycle versions.
+> This project is deprecated (and about to be sunset) and does not support modern Buildpack API and lifecycle versions.
 >
 > Please switch to native CNB implementations rather than using this shim.
 >
 > See [Heroku's natively supported CNB languages](https://github.com/heroku/buildpacks#supported-languages) or [search for community buildpacks](https://registry.buildpacks.io/).
 
-This is a Cloud Native Buildpack that acts as a shim for classic [Heroku Buildpacks](https://devcenter.heroku.com/articles/buildpacks).
-
-## Usage
-
-This shim can be used with any buildpack in the [Heroku Buildpack Registry](https://devcenter.heroku.com/articles/buildpack-registry) by specifying a URL in the form:
-
-```
-https://cnb-shim.herokuapp.com/v1/<namespace>/<name>
-```
-
-### Example: Elixir
-
-```
-$ pack build elixir-app --buildpack https://cnb-shim.herokuapp.com/v1/hashnuke/elixir --builder heroku/buildpacks:18
-```
-
-For a complete list of available buildpacks run the following command from the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli):
-
-```
-$ heroku buildpacks:search
-```
-
-## Applying the Shim Manually
-
-To use the shim manually, install the target buildpack:
-
-```sh-session
-$ sbin/install "path/to/buildpack.toml" "https://example.com/buildpack.tgz"
-```
-
-Then run this buildpack.
-
-### Example: Elixir
-
-To use this shim with the [hashnuke/elixir](https://github.com/HashNuke/heroku-buildpack-elixir) buildpack, install [`pack` CLI](https://github.com/buildpack/pack) and run:
-
-```
-$ cd elixir-cnb
-
-$ curl -L https://github.com/heroku/cnb-shim/releases/download/v0.1/cnb-shim-v0.1.tgz | tar xz
-
-$ cat > buildpack.toml << TOML
-api = "0.2"
-
-[buildpack]
-id = "hashnuke.elixir"
-version = "0.1"
-name = "Elixir"
-
-[[stacks]]
-id = "heroku-22"
-TOML
-
-$ sbin/install buildpack.toml https://buildpack-registry.s3.amazonaws.com/buildpacks/hashnuke/elixir.tgz
-
-$ cd ~/my-elixir-app/
-
-$ pack build elixir-app --builder heroku/buildpacks --buildpack ~/path/to/elixir-cnb
-```
-
-## License
-
-MIT
+This is a Cloud Native Buildpack that acts as a shim for classic [Heroku Buildpacks](https://devcenter.heroku.com/articles/buildpacks#classic-buildpacks).

--- a/bin/build
+++ b/bin/build
@@ -31,30 +31,31 @@ app_dir="$(pwd)"
 # translate new stack ID to old stack ID
 export STACK="$CNB_STACK_ID"
 
+if [[ "${ALLOW_EOL_CNB_SHIM:-}" == "1" ]]; then
+	MSG_PREFIX="WARNING"
+	MSG_FOOTER="Allowing the build to continue since ALLOW_EOL_CNB_SHIM is set."
+else
+	MSG_PREFIX="ERROR"
+	MSG_FOOTER="To ignore this error, set the env var ALLOW_EOL_CNB_SHIM to 1."
+fi
 
 if [[ "${STACK}" == "heroku-"* ]]; then
-	if [[ "${ALLOW_EOL_SHIMMED_BUILDER:-}" == "1" ]]; then
-		MSG_PREFIX="WARNING"
-		MSG_FOOTER="Allowing the build to continue since ALLOW_EOL_SHIMMED_BUILDER is set."
-	else
-		MSG_PREFIX="ERROR"
-		MSG_FOOTER="To ignore this error, set the env var ALLOW_EOL_SHIMMED_BUILDER to 1."
-	fi
-
 	display_error "$(cat <<-EOF
 		#######################################################################
 
 		${MSG_PREFIX}: This buildpack is a legacy buildpack that has been shimmed
 		for compatibility with Cloud Native Buildpacks (CNBs) using the
-		cnb-shim service:
-		https://github.com/heroku/cnb-shim
+		cnb-shim service hosted at https://cnb-shim.herokuapp.com.
 
-		The cnb-shim service is not actively maintained and does not support
-		modern Buildpack API and lifecycle versions.
+		The cnb-shim service isn't actively maintained and doesn't support
+		modern Buildpack API and lifecycle versions. As such, it's being
+		sunset and the hosted instance will be switched off soon:
+		https://github.com/heroku/cnb-shim/issues/95
 
 		In addition, the legacy builder images that use shimmed buildpacks
 		(such as 'heroku/buildpacks:20' or 'heroku/builder-classic:22') are
-		no longer supported and do not receive any security updates or fixes.
+		no longer supported and so haven't received security updates since
+		May 2024.
 
 		Please switch to one of our newer 'heroku/builder:*' builder images:
 		https://github.com/heroku/cnb-builder-images#available-images
@@ -81,24 +82,22 @@ if [[ "${STACK}" == "heroku-"* ]]; then
 		#######################################################################
 		EOF
 	)"
-
-	if [[ "${ALLOW_EOL_SHIMMED_BUILDER:-}" != "1" ]]; then
-		exit 1
-	fi
 else
-	display_error "$(cat <<-'EOF'
+	display_error "$(cat <<-EOF
 		#######################################################################
 
-		WARNING: This buildpack is a legacy buildpack that has been shimmed
+		${MSG_PREFIX}: This buildpack is a legacy buildpack that has been shimmed
 		for compatibility with Cloud Native Buildpacks (CNBs) using the
 		cnb-shim service:
 		https://github.com/heroku/cnb-shim
 
-		The cnb-shim service is not actively maintained and does not support
-		modern Buildpack API and lifecycle versions.
+		The cnb-shim service isn't actively maintained and doesn't support
+		modern Buildpack API and lifecycle versions. As such, it's being
+		sunset and the hosted instance will be switched off soon:
+		https://github.com/heroku/cnb-shim/issues/95
 
-		Please switch to a buildpack that supports CNBs natively and so does
-		not need shimming.
+		Please switch to a buildpack that supports CNBs natively and so doesn't
+		need shimming.
 
 		See here for Heroku's supported CNB languages:
 		https://github.com/heroku/buildpacks#supported-languages
@@ -106,9 +105,15 @@ else
 		Or search for community buildpacks here:
 		https://registry.buildpacks.io/
 
+		${MSG_FOOTER}
+
 		#######################################################################
 		EOF
 	)"
+fi
+
+if [[ "${ALLOW_EOL_CNB_SHIM:-}" != "1" ]]; then
+	exit 1
 fi
 
 # copy the buildpack source into the target dir

--- a/build_test.go
+++ b/build_test.go
@@ -36,7 +36,7 @@ func TestBuild(t *testing.T) {
 	var out bytes.Buffer
 	cmd := exec.Command(tmp+"/buildpack/bin/build", tmp+"/layers", tmp+"/platform")
 	cmd.Dir = tmp + "/app"
-	cmd.Env = append(os.Environ(), "CNB_STACK_ID=heroku-20", "ALLOW_EOL_SHIMMED_BUILDER=1")
+	cmd.Env = append(os.Environ(), "CNB_STACK_ID=heroku-20", "ALLOW_EOL_CNB_SHIM=1")
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	err = cmd.Run()


### PR DESCRIPTION
* The build-time messaging now explicitly mentions the sunset rather than just the service not being maintained.
* The env var to opt out of the error has been renamed from `ALLOW_EOL_SHIMMED_BUILDER` to `ALLOW_EOL_CNB_SHIM` so that (a) it's more accurate now that the shim is no longer consumed via the builders being published, (b) so that anyone who previously skipped the error using the env var gets another reminder until they update their env var again.
* The non-Heroku-stack path (which the Splunk logs show as being unused in the last 7 days) now also shows an error and not just a warning (but can still be disabled via the env var).
* The README has been updated to mention the sunset.

Refs #95.
GUS-W-19793061.